### PR TITLE
fix: omit password length validation, as hashed passwords are longer than that

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,7 +58,6 @@ model User {
   email    String      @unique()
   /// @password
   /// @omit
-  /// @length(6, 32)
   password String
   name     String?
   spaces   SpaceUser[]

--- a/schema.zmodel
+++ b/schema.zmodel
@@ -77,7 +77,7 @@ model SpaceUser {
 model User {
   id       String      @id @default(cuid())
   email    String      @unique @email
-  password String      @password @omit @length(6, 32)
+  password String      @password @omit
   name     String?
   spaces   SpaceUser[]
   todos    Todo[]


### PR DESCRIPTION
When creating an account with the password length validation active, I get the following error. The validation is applied to the hashed password and a bcrypt hashed password [is 59 or 60 characters long](https://stackoverflow.com/a/5882472), thus this will always be too long. It seems more sensible to completely omit the length validation, given that all other samples don't have it either.

```
Error calling enhanced Prisma method `user.create`: denied by policy: user entities failed 'create' check, input failed validation: Validation error: String must contain at most 32 character(s) at "password"
    at default (C:/px/zenstack/sample-todo-sveltekit/src/routes/(auth)/signup/+page.server.ts:27:34),
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5),
    at async Module.handle_action_json_request (C:/px/zenstack/sample-todo-sveltekit/node_modules/@sveltejs/kit/src/runtime/server/page/actions.js:57:16),
    at async resolve (C:/px/zenstack/sample-todo-sveltekit/node_modules/@sveltejs/kit/src/runtime/server/respond.js:412:18),
    at async Module.respond (C:/px/zenstack/sample-todo-sveltekit/node_modules/@sveltejs/kit/src/runtime/server/respond.js:279:20),
    at async file:///C:/px/zenstack/sample-todo-sveltekit/node_modules/@sveltejs/kit/src/exports/vite/dev/index.js:505:22 {
  name: 'PrismaClientKnownRequestError',
  code: 'P2004',
  clientVersion: '2.1.2',
  meta: {
    reason: 'DATA_VALIDATION_VIOLATION',
    zodErrors: ZodError: [
      {
        "code": "too_big",
        "maximum": 32,
        "type": "string",
        "inclusive": true,
        "exact": false,
        "message": "String must contain at most 32 character(s)",
        "path": [
          "password"
        ]
      }
    ]
        at get error [as error] (C:\px\zenstack\sample-todo-sveltekit\node_modules\zod\lib\types.js:43:31)
        at PolicyProxyHandler.validateCreateInputSchema (C:\px\zenstack\sample-todo-sveltekit\node_modules\@zenstackhq\runtime\enhancements\policy\handler.js:341:153)
        at PolicyProxyHandler.<anonymous> (C:\px\zenstack\sample-todo-sveltekit\node_modules\@zenstackhq\runtime\enhancements\policy\handler.js:142:38)
        at Generator.next (<anonymous>)
        at C:\px\zenstack\sample-todo-sveltekit\node_modules\@zenstackhq\runtime\enhancements\policy\handler.js:9:71
        at new Promise (<anonymous>)
        at __awaiter (C:\px\zenstack\sample-todo-sveltekit\node_modules\@zenstackhq\runtime\enhancements\policy\handler.js:5:12)
        at C:\px\zenstack\sample-todo-sveltekit\node_modules\@zenstackhq\runtime\enhancements\policy\handler.js:134:94
        at fullDb.$transaction.maxWait (C:\px\zenstack\sample-todo-sveltekit\node_modules\@zenstackhq\runtime\enhancements\query-utils.js:36:24)
        at Proxy._transactionWithCallback (C:\px\zenstack\sample-todo-sveltekit\node_modules\@prisma\client\runtime\library.js:127:9540) {
      issues: [Array],
      addIssue: [Function (anonymous)],
      addIssues: [Function (anonymous)],
      errors: [Array]
    }
  },
  internalStack: 'Error calling enhanced Prisma method `user.create`: denied by policy: user entities failed \'create\' check, input failed validation: Validation error: String must contain at most 32 character(s) at "password"\n' +
    '    at OmitHandler.<anonymous> (C:\\px\\zenstack\\sample-todo-sveltekit\\node_modules\\@zenstackhq\\runtime\\enhancements\\proxy.js:43:60),\n' +
    '    at Generator.next (<anonymous>),\n' +
    '    at fulfilled (C:\\px\\zenstack\\sample-todo-sveltekit\\node_modules\\@zenstackhq\\runtime\\enhancements\\proxy.js:6:58),\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)'
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the password length constraint from the User model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->